### PR TITLE
chore: bump vscode-openshift-connector to v0.6.0

### DIFF
--- a/vscode-openshift-connector/extension.json
+++ b/vscode-openshift-connector/extension.json
@@ -1,4 +1,4 @@
 {
   "repository": "https://github.com/redhat-developer/vscode-openshift-tools",
-  "revision": "v0.2.11"
+  "revision": "v0.6.0"
 }


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

Switches VS Code Openshift connector extension to the latest 0.6.0 release
https://github.com/redhat-developer/vscode-openshift-tools/tree/v0.6.0

Solves https://issues.redhat.com/browse/CRW-3344